### PR TITLE
Fixed issue with multiple maximums in kde throwing warning

### DIFF
--- a/R/Mode.R
+++ b/R/Mode.R
@@ -46,7 +46,8 @@ Mode <- function(x)
      else {
           x <- as.vector(as.numeric(as.character(x)))
           kde <- density(x)
-          Mode <- kde$x[kde$y == max(kde$y)]}
+          Mode <- kde$x[kde$y == max(kde$y)][1]
+          }
      return(Mode)
      }
 Modes <- function(x, min.size=0.1) {
@@ -83,8 +84,8 @@ Modes <- function(x, min.size=0.1) {
           kde <- dens
           kde$x <- kde$x[begin[j]:begin[j+2]]
           kde$y <- kde$y[begin[j]:begin[j+2]]
-          modes[i] <- kde$x[kde$y == max(kde$y)]
-          mode.dens[i] <- kde$y[kde$y == max(kde$y)]
+          modes[i] <- kde$x[kde$y == max(kde$y)][1]
+          mode.dens[i] <- kde$y[kde$y == max(kde$y)][1]
           j <- j + 2
           }
      ### Order everything by density


### PR DESCRIPTION
There were lines in Mode.R that used some variant of the following code:

```r
modes[i] <- kde$x[kde$y == max(kde$y)]
```

However, in my use of the `Modes` function, sometimes multiple values of `kde$y` were equal to the maximum, which would cause the function to throw a warning, since `kde$x[kde$y == max(kde$y)]` would be a vector, rather than a scalar. I have changed it so that if this is the case, it only returns a scalar.