### PR TITLE
fix dmvl

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1362,9 +1362,9 @@ dmvl <- function(x, mu, Sigma, log=FALSE)
      ss <- x - mu
      z <- rowSums({ss %*% Omega} * ss)
      z[which(z == 0)] <- 1e-300
-     dens <- as.vector(log(2) - log(2*pi)*(k/2) + logdet(Sigma)*0.5 +
-          (log(pi) - log(2) + log(2*z)*0.5)*0.5 - sqrt(2*z) -
-          log(z/2)*0.5*(k/2 - 1))
+     dens <- as.vector(log(2) - log(2 * pi) * (k/2) - logdet(Sigma) * 0.5 + 
+                      (log(pi) - log(2) - log(2 * z) * 0.5) * 0.5 - 
+                      sqrt(2 * z) - log(z/2) * 0.5 * (k/2 - 1))
      if(log == FALSE) dens <- exp(dens)
      return(dens)
      }


### PR DESCRIPTION
Using the following code, the density of a two-dimensional Laplace distribution can be plotted with the original function dmvl and the new version of the function dmvl (see #24). When looking at the plot for the original version, it is obvious that the density is not correct. This is fixed in the new version which leads to a reasonable plot. 

```
# new version of dmvl:
dmvl = function (x, mu, Sigma, log = FALSE) {
  if (!is.matrix(x))
    x <- rbind(x)
  if (!is.matrix(mu))
    mu <- matrix(mu, nrow(x), ncol(x), byrow = TRUE)
  if (missing(Sigma))
    Sigma <- diag(ncol(x))
  if (!is.matrix(Sigma))
    Sigma <- matrix(Sigma)
  Sigma <- LaplacesDemon::as.symmetric.matrix(Sigma)
  if (!LaplacesDemon::is.positive.definite(Sigma))
    stop("Matrix Sigma is not positive-definite.")
  k <- nrow(Sigma)
  Omega <- LaplacesDemon::as.inverse(Sigma)
  ss <- x - mu
  z <- rowSums({
    ss %*% Omega
  } * ss)
  z[which(z == 0)] <- 1e-300
  dens <- as.vector(log(2) - log(2 * pi) * (k/2) - LaplacesDemon::logdet(Sigma) *
                      0.5 + (log(pi) - log(2) - log(2 * z) * 0.5) * 0.5 -
                      sqrt(2 * z) - log(z/2) * 0.5 * (k/2 - 1))
  if (log == FALSE)
    dens <- exp(dens)
  return(dens)
}

# grid for evaluating density:
grid = expand.grid(x1 = seq(from = -1, to = 1, length.out = 100),
                   x2 = seq(from = -1, to = 1, length.out = 100))

# calculate density values for original version of dmvl:
dmvl_original = apply(X = grid, MARGIN = 1, FUN = function(x)
  LaplacesDemon::dmvl(x = x, mu = c(0, 0), Sigma = diag(2)))

# plot density of original version of dmvl:
rgl::plot3d(grid$x1, grid$x2, dmvl_original)

# calculate density values for new version of dmvl:
dmvl_new = apply(X = grid, MARGIN = 1, FUN = function(x)
  dmvl(x = x, mu = c(0, 0), Sigma = diag(2)))

# plot density of new version of dmvl:
rgl::plot3d(grid$x1, grid$x2, dmvl_new)
```