### PR TITLE
Radius parameter of multivariate exponential power distribution

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1604,7 +1604,7 @@ rmvpe <- function(n, mu=c(0,0), Sigma=diag(2), kappa=1)
           stop("Sigma must be positive-definite.")}
      SigmaSqrt <- ev$vectors %*% diag(sqrt(ev$values),
           length(ev$values)) %*% t(ev$vectors)
-     radius <- (rgamma(n, shape=k/(2*kappa), scale=1/2))^(1/(2*kappa))
+     radius <- (rgamma(n, shape=k/(2*kappa), scale=2))^(1/(2*kappa))
      runifsphere <- function(n, k)
           {
           p <- as.integer(k)


### PR DESCRIPTION
Noticed that simulated data from the multivariate exponential power distribution does not give expected covariance. The problem lies in the radius parameter which is gamma distribution with shape = 1/2. The code sets it as scale = 1/2 , see [Gómez et al. (1998)](https://www.tandfonline.com/doi/pdf/10.1080/03610929808832115)